### PR TITLE
[ TID-88 ] no permissions needed to serve media

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -26,7 +26,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'django-insecure-sm^l$qx=e&7q13f(o7&^@e$(^2ta7plc+b6&1yq-bdi4u=m%^%'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = config('DEBUG', default=True, cast=bool)
 
 ALLOWED_HOSTS = []
 

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -17,10 +17,16 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import include, path
 from app.views.media_views import ProtectedMediaView
+from django.conf import settings
+from django.conf.urls.static import static
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', include("app.urls")),
-    path('media/<path:path>', ProtectedMediaView.as_view(), name='protected-media'),
 	path('silk/', include('silk.urls', namespace='silk')),
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+elif settings.PRODUCTION:
+    urlpatterns += [path('media/<path:path>', ProtectedMediaView.as_view())]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
     restart: always
     depends_on:
       - backend
+    env_file:
+      - .env
 
   db:
     container_name: transcendence_db

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,8 @@
     "webpack": "^5.93.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4",
-    "source-map-loader": "^4.0.1"
+    "source-map-loader": "^4.0.1",
+    "dotenv-webpack": "^7.0.3"
   },
   "dependencies": {
     "@popperjs/core": "^2.11.8",

--- a/frontend/src/js/constants.js
+++ b/frontend/src/js/constants.js
@@ -2,3 +2,4 @@ export const EMPTY_AVATAR_URL = "/static/images/empty-avatar.jpg";
 export const API_URL = "http://localhost:8000/api";
 export const MEDIA_URL = "http://localhost:8000/media";
 export const WS_URL = "ws://localhost:8000/ws";
+export const DEBUG = process.env.DEBUG;

--- a/frontend/src/js/customElements/Navbar.js
+++ b/frontend/src/js/customElements/Navbar.js
@@ -1,4 +1,5 @@
 import { EMPTY_AVATAR_URL } from "../constants.js";
+import { getAvatarSrc } from "../utils.js";
 
 class Navbar extends HTMLElement {
     constructor() {
@@ -57,7 +58,7 @@ class Navbar extends HTMLElement {
             <nav class="navbar">
                 <a class="navbar-brand" data-href="/home">PONG</a>
                 <div class="profile navbar-center" data-href="/profile">
-                    <img src={EMPTY_AVATAR_URL} width="40" height="40" alt="Avatar" class="avatar" />
+                    <img src="${EMPTY_AVATAR_URL}" width="40" height="40" alt="Avatar" class="avatar" />
                     <span class="username"></span>
                 </div>
                 <ul class="navbar-nav">
@@ -89,8 +90,7 @@ class Navbar extends HTMLElement {
 
         if (auth.authenticated) {
             const { user } = auth;
-            const avatar_upload = user.avatar_upload ? await api.fetchAvatarObjectUrl(user.avatar_upload) : null;
-            profileEl.querySelector("img").src = avatar_upload || user.avatar_oauth || EMPTY_AVATAR_URL;
+            profileEl.querySelector("img").src = await getAvatarSrc(user, api.fetchAvatarObjectUrl);
             profileEl.querySelector(".username").textContent = user.username;
             profileEl.setAttribute('data-href', `/profile/${user.id}`);
             this.setDisplay([loginEl, registerEl], "none");

--- a/frontend/src/js/customElements/ScoreBoard.js
+++ b/frontend/src/js/customElements/ScoreBoard.js
@@ -1,4 +1,5 @@
 import { EMPTY_AVATAR_URL } from "../constants.js";
+import { getAvatarSrc } from "../utils.js";
 
 class ScoreBoard extends HTMLElement {
     constructor() {
@@ -69,17 +70,17 @@ class ScoreBoard extends HTMLElement {
         const match = await api.getGame(this.page.params.id);
         if (!match) return;
 
-        const setElement = (id, value) => (this.shadowRoot.getElementById(id).textContent = value);
-        const setAvatar = async (id, avatar, oauth) => {
-            this.shadowRoot.getElementById(id).src =
-                avatar ? await api.fetchAvatarObjectUrl(avatar) : oauth || EMPTY_AVATAR_URL;
+        const setElement = (id, value) => this.shadowRoot.getElementById(id).textContent = value;
+        const setAvatar = async (id, user) => {
+            const avatarSrc = await getAvatarSrc(user, api.fetchAvatarObjectUrl);
+            this.shadowRoot.getElementById(id).src = avatarSrc;
         };
-
-        await setAvatar("avatar-1", match.player1.avatar_upload, match.player1.avatar_oauth);
+        
+        await setAvatar("avatar-1", match.player1);
         setElement("username-1", match.player1.username);
         setElement("score-1", match.score_player1);
 
-        await setAvatar("avatar-2", match.player2.avatar_upload, match.player2.avatar_oauth);
+        await setAvatar("avatar-2", match.player2);
         setElement("username-2", match.player2.username);
         setElement("score-2", match.score_player2);
 

--- a/frontend/src/js/customElements/UserProfileCard.js
+++ b/frontend/src/js/customElements/UserProfileCard.js
@@ -1,4 +1,5 @@
 import { EMPTY_AVATAR_URL } from "../constants.js";
+import { getAvatarSrc } from "../utils.js";
 
 class UserProfileCard extends HTMLElement {
     constructor() {
@@ -58,7 +59,6 @@ class UserProfileCard extends HTMLElement {
         const lossesEl = this.shadowRoot.getElementById("profile-losses");
         const profileStats = this.shadowRoot.getElementById("profile-stats");
         const { api } = this.page.app;
-        const avatar_upload = user.avatar_upload ? await api.fetchAvatarObjectUrl(user.avatar_upload): null;
         infoEl.setAttribute('data-href', `/profile/${user.id}`);
 
         this.shadowRoot.querySelectorAll("[data-href]").forEach(element => {
@@ -69,8 +69,8 @@ class UserProfileCard extends HTMLElement {
         usernameEl.style.opacity = 0;
         profileStats.style.opacity = 0;
 
-        setTimeout(() => {
-            avatarEl.src = avatar_upload || user.avatar_oauth || EMPTY_AVATAR_URL;
+        setTimeout(async () => {
+            avatarEl.src = await getAvatarSrc(user, api.fetchAvatarObjectUrl);
             usernameEl.textContent = user.username;
             winsEl.textContent = user.game_stats.wins;
             lossesEl.textContent = user.game_stats.losses;
@@ -79,7 +79,7 @@ class UserProfileCard extends HTMLElement {
             avatarEl.style.opacity = 1;
             usernameEl.style.opacity = 1;
             profileStats.style.opacity = 1;
-        }, 300);
+        }, 100);
     }
 
     disconnectedCallback() {

--- a/frontend/src/js/customElements/UserProfileCardSm.js
+++ b/frontend/src/js/customElements/UserProfileCardSm.js
@@ -1,4 +1,5 @@
 import { EMPTY_AVATAR_URL } from "../constants.js";
+import { getAvatarSrc } from "../utils.js";
 
 class UserProfileCardSm extends HTMLElement {
     constructor() {
@@ -75,9 +76,8 @@ class UserProfileCardSm extends HTMLElement {
         const avatarEl = this.shadowRoot.getElementById("profile-avatar");
         const usernameEl = this.shadowRoot.getElementById("profile-username");
         const { api } = this.page.app;
-        const avatar_upload = user.avatar_upload ? await api.fetchAvatarObjectUrl(user.avatar_upload): null;
 
-        avatarEl.src = avatar_upload || user.avatar_oauth || EMPTY_AVATAR_URL;
+        avatarEl.src = await getAvatarSrc(user, api.fetchAvatarObjectUrl);
         usernameEl.textContent = user.username;
     }
 

--- a/frontend/src/js/utils.js
+++ b/frontend/src/js/utils.js
@@ -1,3 +1,5 @@
+import { EMPTY_AVATAR_URL, DEBUG, MEDIA_URL } from "./constants.js";
+
 export function capitalizeFirstLetter(message) {
 	return message.charAt(0).toUpperCase() + message.slice(1);
 }
@@ -48,4 +50,14 @@ export function parsePath(path, pages) {
 export function formatDate(dateString) {
     const date = new Date(dateString);
     return `${date.getDate().toString().padStart(2, '0')}/${(date.getMonth() + 1).toString().padStart(2, '0')}/${date.getFullYear().toString().slice(-2)}`;
+}
+
+export async function getAvatarSrc(user, apiFetchCallback) {
+    if (!user) return null;
+
+    const avatar_upload = DEBUG 
+    ? (user.avatar_upload ? `${MEDIA_URL}/${user.avatar_upload}` : null) 
+    : (user.avatar_upload ? await apiFetchCallback(user.avatar_upload) : null);
+
+    return avatar_upload || user.avatar_oauth || EMPTY_AVATAR_URL;
 }

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -3,6 +3,7 @@
 const path = require("path");
 const autoprefixer = require("autoprefixer");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
+const Dotenv = require('dotenv-webpack');
 
 module.exports = {
     mode: "development",
@@ -29,6 +30,7 @@ module.exports = {
             template: "./src/index.html",
             filename: "index.html",
         }),
+        new Dotenv({systemvars: true}),
     ],
     module: {
         rules: [


### PR DESCRIPTION
- Added non protected routing for media to simplify dev environment media serving
- Added dotenv to webpack so front end can access env variables
- Added DEBUG constant, to be used both in front and back end (DEBUG=True must be added to .env) 
- Adapted front end classes to do non auth media requests

Features / to test;
- Images serving and requests work
- JWT are not used for media

____________________________________


### Environment Variables and Configuration:

* [`backend/backend/settings.py`](diffhunk://#diff-14b271df07b547d8d4af7796ce96f827e59fb6fcdb85296af8d6825d7a06b0a9L29-R29): Updated the `DEBUG` setting to use the `config` function to fetch the value from environment variables.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R32-R33): Added an `env_file` directive to the `services` section to load environment variables from a `.env` file.

### Avatar URL Management:

* [`frontend/src/js/utils.js`](diffhunk://#diff-958717875080c7c313152c88bed719c7fff77f15eaec0e11e3a86aea2bc2d0f3R54-R63): Introduced a new `getAvatarSrc` function to centralize the logic for determining the avatar URL based on environment variables and user data.
* Updated multiple components (`Navbar`, `ScoreBoard`, `UserProfileCard`, `UserProfileCardSm`) to use the new `getAvatarSrc` function for setting avatar URLs. [[1]](diffhunk://#diff-f08263b586b5e02f05e28258298ce591829f1a7850b9e4a607f487c3703355e2R2) [[2]](diffhunk://#diff-e2a4ef3049a7cb1c2e0883624fca6c2ca1009f1d23c16de59651dfcb12a1c8bbR2) [[3]](diffhunk://#diff-c78174c8ac789a0fa0c34021f3840eafca5d58769c64ffdddb4e91b4ae760c17R2) [[4]](diffhunk://#diff-85bfa8e1ea6c79d400d99e8a9f8d1834e9e4609843b6aea77426eec6b60900c1R2)

### Frontend Build Process:

* [`frontend/package.json`](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L25-R26): Added the `dotenv-webpack` package to manage environment variables in the frontend build process.
* [`frontend/webpack.config.js`](diffhunk://#diff-eb6063fd4b754545b1a874dc0b922bb0fdf014ddc7a9f0eba7e058c8f157be05R6): Configured `dotenv-webpack` to load environment variables during the build process. [[1]](diffhunk://#diff-eb6063fd4b754545b1a874dc0b922bb0fdf014ddc7a9f0eba7e058c8f157be05R6) [[2]](diffhunk://#diff-eb6063fd4b754545b1a874dc0b922bb0fdf014ddc7a9f0eba7e058c8f157be05R33)

### URL Configuration:

* [`backend/backend/urls.py`](diffhunk://#diff-0caed16cadc3aaaed0d2c84e00a77735b51f56b4618410052a17fc19db6c9bb0R20-R32): Updated the URL configuration to serve static media files based on the `DEBUG` and `PRODUCTION` settings.
