### PR TITLE
[ TID-82 ] Login with username

### DIFF
--- a/backend/app/views/auth_views.py
+++ b/backend/app/views/auth_views.py
@@ -47,7 +47,7 @@ class LoginView(TwoFactorAuthView):
                 'otp_token': otp_token,
             })
         
-        return generate_jwt_response(user, serializer.validated_data['refresh'])
+        return generate_jwt_response(user)
 
 class VerifyEmailView(APIView):
     permission_classes = [AllowAny]

--- a/backend/app/views/serializers.py
+++ b/backend/app/views/serializers.py
@@ -6,9 +6,10 @@ from django.contrib.auth.password_validation import validate_password
 from django.conf import settings
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError, APIException
-from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 from user.models import GameStats
 from app.models import GameInvitation, PongGame
+from django.db.models import Q
+from rest_framework.exceptions import AuthenticationFailed
 
 User = get_user_model()
 logger = logging.getLogger(__name__)
@@ -18,13 +19,32 @@ class EmailNotVerifiedException(APIException):
     default_detail = "Email is not verified."
     default_code = "email_not_verified"
 
-class LoginSerializer(TokenObtainPairSerializer):
+class LoginSerializer(serializers.Serializer):
+    email_or_username = serializers.CharField(write_only=True)
+    password = serializers.CharField(write_only=True, style={'input_type': 'password'})
+
     def validate(self, attrs):
-        data = super().validate(attrs)
-        if not self.user.email_is_verified:
+        email_or_username = attrs.get('email_or_username')
+        password = attrs.get('password')
+
+        if not email_or_username or not password:
+            raise serializers.ValidationError(
+                ('Must include "email_or_username" and "password".'),
+                'missing_fields'
+            )
+
+        user = User.objects.filter(
+            Q(email__iexact=email_or_username) | 
+            Q(username__iexact=email_or_username)
+        ).first()
+
+        if not user or not user.check_password(password):
+            raise AuthenticationFailed()
+
+        if not user.email_is_verified:
             raise EmailNotVerifiedException()
-        data['user'] = self.user
-        return data
+
+        return {'user': user}
 
 class GameStatsSerializer(serializers.ModelSerializer):
     class Meta:

--- a/backend/app/views/services.py
+++ b/backend/app/views/services.py
@@ -39,12 +39,11 @@ def send_verification_email(user):
     )
     logger.info(f"Verification email sent to user ID {user.id}")
         
-def generate_jwt_response(user, refresh=None):
+def generate_jwt_response(user):
     """
     Generate a JWT response for the user. If no refresh token is provided, a new one is created.
     """
-    if not refresh or not isinstance(refresh, RefreshToken):
-        refresh = RefreshToken.for_user(user)
+    refresh = RefreshToken.for_user(user)
     access = refresh.access_token
     return Response({
         "refresh": str(refresh),

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -35,12 +35,11 @@
                     <custom-form id="login-form">
                         <h1 class="h3 mb-3 fw-normal">Please sign in</h1>
                         <div class="form-floating mb-3">
-                            <input type="email" class="form-control" data-id="Email" placeholder="name@example.com"
-                                autocomplete="email" />
-                            <label for="Email">Email address</label>
+                            <input type="email" class="form-control" data-id="Email"/>
+                            <label for="Email">Username or email</label>
                         </div>
                         <div class="form-floating mb-3">
-                            <input type="password" class="form-control" data-id="Password" placeholder="Password" />
+                            <input type="password" class="form-control" data-id="Password" />
                             <label for="Password">Password</label>
                         </div>
                         <button class="btn btn-primary w-100 py-2" type="submit">

--- a/frontend/src/js/Api.js
+++ b/frontend/src/js/Api.js
@@ -111,7 +111,7 @@ export class Api {
      */
     async login(email, password) {
         return this.request("post", "/token/", {
-            email: email,
+            email_or_username: email,
             password: password,
         });
     }


### PR DESCRIPTION
Feature / to test:

Can now login with username and password

_______________________________________

Backend changes:

* [`backend/app/views/auth_views.py`](diffhunk://#diff-fa39e5e45926c55c2165377e1057ac98b04407d336c4810785eb8464368fe99fL50-R50): Modified the `post` method to simplify the `generate_jwt_response` call by removing the `refresh` parameter.
* [`backend/app/views/serializers.py`](diffhunk://#diff-49c62ea6eb6cf2f0472680444ee54665a6a9b81ba17bfc179d8049b84b07ccfeL21-R47): Updated the `LoginSerializer` to accept either `email_or_username` and `password`, and added validation logic for these fields. Removed the dependency on `TokenObtainPairSerializer`.
* [`backend/app/views/services.py`](diffhunk://#diff-4396879cbef972cf2b49fccaeb4681375bc186a97cc42ccbda209389a83e5bd4L42-L46): Simplified the `generate_jwt_response` function by removing the `refresh` parameter and its associated logic.

Frontend changes:

* [`frontend/src/index.html`](diffhunk://#diff-1871fc7d48e49a8b5e54149bb3d277640eb0818d14aed00b20ebc52a3f81e3dbL38-R42): Updated the login form to label the input field as "Username or email" instead of "Email address".
* [`frontend/src/js/Api.js`](diffhunk://#diff-baefc9bb54df6008c7fbdede5e079177c7017e8ae4cd6b03165983144294794eL114-R114): Modified the `login` method to send `email_or_username` instead of `email` to the backend.

