### PR TITLE
TID-30 added swagger and redoc for improved API documentation and testing

### DIFF
--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -77,7 +77,8 @@ INSTALLED_APPS = [
     'channels',
     'corsheaders',
     'rest_framework_simplejwt.token_blacklist',
-    'silk'
+    'silk',
+    'drf_yasg'
 ]
 
 ASGI_APPLICATION = 'app.asgi.application'

--- a/backend/app/urls.py
+++ b/backend/app/urls.py
@@ -10,9 +10,26 @@ from django.urls import include, path
 from django.conf import settings
 from django.conf.urls.static import static
 from app.views import ProtectedMediaView
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
 
+
+schema_view = get_schema_view(
+    openapi.Info(
+        title="Transcendence API",
+        default_version='v1',
+        description="API documentation",
+        license=openapi.License(name="BSD License"),
+    ),
+    public=True,
+    permission_classes=(permissions.AllowAny,),
+)
 
 urlpatterns = [
+    path('swagger<format>/', schema_view.without_ui(cache_timeout=0), name='schema-json'),
+    path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
     # Admin
     path('admin/', admin.site.urls),
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,3 +15,4 @@ django-silk
 faker
 qrcode
 django-crontab
+drf_yasg


### PR DESCRIPTION
This pull request introduces interactive API documentation for our web API by integrating both Swagger UI and Redoc.

- **Redoc:**  Accessible at `https://localhost:8000/redoc/`
- **Open API Swagger:**  Accessible at `https://localhost:8000/swagger/`
- **YAML Specification:** Accessible at `http://localhost:8000/swagger.yaml/`
- **JSON Specification:** Accessible at `http://localhost:8000/swagger.json/`

