### PR TITLE
[TID-96] Explicitly add password hashers to settings

### DIFF
--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -32,6 +32,14 @@ PRODUCTION = not DEBUG
 #ALLOWED_HOSTS = ["localhost", "127.0.0.1", "172.22.0.1"]
 ALLOWED_HOSTS = config('ALLOWED_HOSTS', default='localhost').split(',')
 
+PASSWORD_HASHERS = [
+    "django.contrib.auth.hashers.PBKDF2PasswordHasher",
+    "django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher",
+    "django.contrib.auth.hashers.Argon2PasswordHasher",
+    "django.contrib.auth.hashers.BCryptSHA256PasswordHasher",
+    "django.contrib.auth.hashers.ScryptPasswordHasher",
+]
+
 # jwt settings
 SIMPLE_JWT = {
     'ACCESS_TOKEN_LIFETIME': timedelta(minutes=int(config('ACCESS_TOKEN_LIFETIME', default='60'))),


### PR DESCRIPTION
Django handles strong password hashing “out of the box” in a few key ways:

   - By default, Django includes hashers like PBKDF2 (with a high iteration count). 
   - Django automatically salts each password before hashing.  
   - Django’s default PBKDF2 hasher uses tens of thousands of iterations-
   - Django tries all the hashers in the `PASSWORD_HASHERS` list to verify a user’s password.  
   - If the password matches via an older hasher (e.g., Bcrypt), Django immediately rehashes it with the “current” (first-listed) hasher (e.g., Argon2). This way, old hashes get seamlessly upgraded.
   - We can reorder or add hashers in `PASSWORD_HASHERS` to choose stronger algorithms (like Argon2 or Scrypt).  
   - We can also change the iteration counts or memory usage for Argon2/Scrypt.