### PR TITLE
Arrange the hendel invitation

### DIFF
--- a/frontend/src/js/WebSocketManager.js
+++ b/frontend/src/js/WebSocketManager.js
@@ -75,10 +75,10 @@ export class WebSocketManager {
     async handleGameInvitationMessage(event) {
         const data = JSON.parse(event.data);
         if (data.type === "game_accepted") {
-            if (this.app.stateManager.currentGame) return;
+            if (this.app.stateManager.state.currentGame) return;
             this.app.navigate(data.game_url);
         } else if (data.type === "game_invited") {
-            if (this.app.stateManager.currentGame) return;
+            if (this.app.stateManager.state.currentGame) return;
             if (confirm(`You have been challenged by ${data.invitation.sender.username}. Do you accept?`)) {
                 try {
                     const response = await this.app.api.gameAccept(data.invitation.id);

--- a/frontend/src/js/customElements/PongRemote.js
+++ b/frontend/src/js/customElements/PongRemote.js
@@ -122,15 +122,15 @@ class PongRemote extends Pong {
                 break;
         }
     }
-
-    toggleBallDisplay(message) {
-        if (message === "score") {
-            this.ball.style.display = "none";
-        } else if (message === "gameState" && this.ball.style.display === "none") {
-            setTimeout(() => this.ball.style.display = "block", 500);
-        }
-    }
-
+	toggleBallDisplay(message) {
+		if (message === "score") {
+			this.ball.style.display = "none";
+		} else if (message === "gameState" && this.ball.style.display === "none") {
+			setTimeout(() => {
+				if (!this.gameOver) this.ball.style.display = "block";
+			}, 500);
+		}
+	}
     updateStatus(message) {
         this.statusMessage.textContent = message;
     }


### PR DESCRIPTION
This pull request includes updates to improve the handling of game invitations and the display of the ball in the Pong game. The most important changes include modifications to the `WebSocketManager` and `PongRemote` classes.

Improvements to game invitation handling:

* [`frontend/src/js/WebSocketManager.js`](diffhunk://#diff-e5c437f877957670244ae1b0f77076a51e7a5a15c59a37ea53cf6cd9bbc13c19L78-R81): Updated the `handleGameInvitationMessage` method to correctly reference `currentGame` within the `state` object.

Enhancements to Pong game display:

* [`frontend/src/js/customElements/PongRemote.js`](diffhunk://#diff-722b93b6fbb9becfcae2f7024dc66c8cb21d3ad219d41517c87471ca24ebd97dL125-L133): Modified the `toggleBallDisplay` method to ensure the ball is only displayed if the game is not over.