### PR TITLE
[TID-172] Update Docker images versions and increase Vault startup wait time

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,7 +107,7 @@ services:
     restart: unless-stopped
   waf:
     container_name: modecurity_waf
-    image: bit3/nginx-waf:latest
+    image: bit3/nginx-waf:1.23.1
     platform: linux/amd64
     expose:
       - 8081

--- a/hashiCorpVault/src/vault-entrypoint.sh
+++ b/hashiCorpVault/src/vault-entrypoint.sh
@@ -39,7 +39,7 @@ $VAULT_BIN server -config=/vault/config/vault.hcl &
 VAULT_PID=$!
 
 echo "Waiting for Vault to be ready..."
-sleep 10
+sleep 30
 
 # Vault initialization and unseal process with error checks
 if [ "$($VAULT_BIN status -format=json | jq -r '.initialized')" == "false" ]; then

--- a/reverse_proxy/Dockerfile
+++ b/reverse_proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:latest
+FROM nginx:1.27.4
 
 RUN apt update && \
     apt install -y jq curl && \


### PR DESCRIPTION
- Changed WAF image version from latest to 1.23.1 for stability.
- Updated reverse proxy base image to nginx:1.27.4 for security.
- Increased Vault initialization wait time from 10 to 30 seconds to ensure readiness.