### PR TITLE
Fix/waf thresholds

### DIFF
--- a/modsecurity_waf/crs-setup.conf
+++ b/modsecurity_waf/crs-setup.conf
@@ -314,7 +314,7 @@ SecAction \
   nolog,\
   pass,\
   t:none,\
-  setvar:tx.inbound_anomaly_score_threshold=15,\
+  setvar:tx.inbound_anomaly_score_threshold=5,\
   setvar:tx.outbound_anomaly_score_threshold=4"
 
 

--- a/modsecurity_waf/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
+++ b/modsecurity_waf/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf
@@ -163,3 +163,11 @@
 # REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf
 # REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf
 # bring additional examples which can be useful then tuning a service.
+
+# Exclusion Rule: Allow all PATCH requests
+SecRule REQUEST_METHOD "PATCH" \
+    "id:1006,\
+    phase:1,\
+    pass,\
+    nolog,\
+    ctl:ruleEngine=Off"


### PR DESCRIPTION
This pull request includes changes to the ModSecurity Web Application Firewall (WAF) configuration files to adjust anomaly score thresholds and add an exclusion rule for PATCH requests. These updates aim to fine-tune the security settings and provide more flexibility for specific HTTP methods.

### Adjustments to anomaly score thresholds:
* [`modsecurity_waf/crs-setup.conf`](diffhunk://#diff-5f44670859b8f7346c2f591ebe837368aed64efbe36ad6809e9c0329acd7e84fL317-R317): Reduced the `tx.inbound_anomaly_score_threshold` from 15 to 5 to enforce stricter inbound anomaly detection.

### New exclusion rule:
* [`modsecurity_waf/rules/REQUEST-900-EXCLUSION-RULES-BEFORE-CRS.conf`](diffhunk://#diff-452f9212b1a76b1efa17a9cb68d70d6daccd8d09eb2d9f4589810270b4d8a78bR166-R173): Added a new exclusion rule to allow all HTTP PATCH requests by disabling the rule engine for this method.